### PR TITLE
add support to slow mode in kflash

### DIFF
--- a/boards/sipeed-maix-go.json
+++ b/boards/sipeed-maix-go.json
@@ -21,7 +21,8 @@
         "maximum_size": 16777216,
         "burn_tool": "goE",
         "require_upload_port": true,
-        "speed": 2000000
+        "speed": 2000000,
+        "slow": false
     },
     "url": "https://www.sipeed.com/",
     "vendor": "Sipeed"

--- a/builder/main.py
+++ b/builder/main.py
@@ -104,7 +104,8 @@ if upload_protocol == "kflash":
             # "-n",
             "-p", port_str,
             "-b", "$UPLOAD_SPEED",
-            "-B", board.get("upload.burn_tool")
+            "-B", board.get("upload.burn_tool"),
+            "-S" if board.get("upload.slow") else ""
         ],
 
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE',


### PR DESCRIPTION
Need to fix a bug in kflash.py synchronously.
Add `action="store_true"` to `-S` argument at line 1123 in kflash.py.