### PR TITLE
Allow using custom linker script

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -63,9 +63,8 @@ env.Append(
     
 )
 
-env.Replace(
-    LDSCRIPT_PATH = join(SDK_DIR,"lds","kendryte.ld")
-)
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=join(SDK_DIR, "lds", "kendryte.ld"))
 
 #
 # Target: Build Core Library

--- a/builder/frameworks/kendryte-freertos-sdk.py
+++ b/builder/frameworks/kendryte-freertos-sdk.py
@@ -110,9 +110,8 @@ env.Append(
 
 )
 
-env.Replace(
-    LDSCRIPT_PATH = join(FRAMEWORK_DIR,"lds","kendryte.ld")
-)
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "lds", "kendryte.ld"))
 
 #
 # Target: Build Core Library

--- a/builder/frameworks/kendryte-standalone-sdk.py
+++ b/builder/frameworks/kendryte-standalone-sdk.py
@@ -54,9 +54,8 @@ env.Append(
 
 )
 
-env.Replace(
-    LDSCRIPT_PATH = join(FRAMEWORK_DIR,"lds","kendryte.ld")
-)
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "lds", "kendryte.ld"))
 
 #
 # Target: Build Core Library


### PR DESCRIPTION
This will allow users to set any linker script from `platformio.ini` file using the following syntax:
```ini
[env:sipeed-maix-go]
platform = kendryte210
framework = arduino
board = sipeed-maix-go
monitor_speed = 115200

board_build.ldscript = custom_ldscript.ld
```
This is a more correct way of specifying it in comparison with using the `-Wl,-T` flag.