### PR TITLE
Move crtend files to end of link command to prevent exceptions causing fatal sys_exit

### DIFF
--- a/builder/frameworks/kendryte-freertos-sdk.py
+++ b/builder/frameworks/kendryte-freertos-sdk.py
@@ -103,7 +103,7 @@ env.Append(
     ],
 
     LIBS = [
-        "c", "gcc", "m", "stdc++", "atomic"                                                                                                                 
+        "c", "gcc", "m", "stdc++", "atomic"
     ]
 
 )

--- a/builder/frameworks/kendryte-freertos-sdk.py
+++ b/builder/frameworks/kendryte-freertos-sdk.py
@@ -70,8 +70,6 @@ env.Append(
         "-Wl,--end-group",
         join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crti.o"),
         join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtbegin.o"),
-        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtend.o"),
-        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtn.o")
     ],
 
     CPPPATH = [
@@ -105,13 +103,20 @@ env.Append(
     ],
 
     LIBS = [
-        "c", "gcc", "m", "stdc++", "atomic"
+        "c", "gcc", "m", "stdc++", "atomic"                                                                                                                 
     ]
 
 )
 
 if not env.BoardConfig().get("build.ldscript", ""):
     env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "lds", "kendryte.ld"))
+
+env.Append(CRTEND=[
+    join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtend.o"),
+    join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtn.o")
+])
+
+env.Append(LINKCOM=" $CRTEND")
 
 #
 # Target: Build Core Library


### PR DESCRIPTION
Fixes #32:

Update freertos scons script to move crtend.o and crtn.o to end of link command.