### PR TITLE
Added missing defines to fix compiler warnings

### DIFF
--- a/boards/sipeed-maix-go.json
+++ b/boards/sipeed-maix-go.json
@@ -1,6 +1,6 @@
 {
     "build": {
-        "extra_flags": "",
+        "extra_flags": "-DBOARD_SIPEED_MAIX_GO",
         "f_cpu": "400000000L",
         "mcu": "K210",
         "hwids": [

--- a/boards/sipeed-maix-one-dock.json
+++ b/boards/sipeed-maix-one-dock.json
@@ -1,6 +1,6 @@
 {
     "build": {
-        "extra_flags": "",
+        "extra_flags": "-DBOARD_SIPEED_MAIX_ONE_DOCK",
         "f_cpu": "400000000L",
         "mcu": "K210",
         "hwids": [


### PR DESCRIPTION
Fixes compiler warning about missing return value in `cores/arduino/wiring_analog.c` and `libraries/Sipeed_ST7789/src/Sipeed_ST7789.h`