### PR TITLE
Default the value of upload.slow to avoid build error

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -105,7 +105,7 @@ if upload_protocol == "kflash":
             "-p", port_str,
             "-b", "$UPLOAD_SPEED",
             "-B", board.get("upload.burn_tool"),
-            "-S" if board.get("upload.slow") else ""
+            "-S" if board.get("upload.slow", False) else ""
         ],
 
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE',


### PR DESCRIPTION
Default the value of upload.slow to avoid build errors for boards when this field is not specified. This issue was introduced in #22 