### PR TITLE
Update framework-kendryte-standalone-sdk version and builder script

### DIFF
--- a/builder/frameworks/kendryte-standalone-sdk.py
+++ b/builder/frameworks/kendryte-standalone-sdk.py
@@ -29,14 +29,14 @@ env.Append(
 
     LINKFLAGS = [
         "-Wl,--start-group",
-        # explicitly add C runtime initialization and end, otherwise "undefined reference to `__dso_handle'"
-        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crti.o"),
-        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtbegin.o"),
+        # explicitly add C runtime initialization and end like SDK, otherwise "undefined reference to `__dso_handle'"
+        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crti.o"),
+        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtbegin.o"),
         "-lgcc",
         "-lm",
         "-lc",
-        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtend.o"),
-        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtn.o"),
+        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtend.o"),
+        join(TOOLCHAIN_DIR, "lib", "gcc", "riscv64-unknown-elf", "8.2.0", "crtn.o"),
         "-Wl,--end-group",
     ],
 

--- a/builder/frameworks/kendryte-standalone-sdk.py
+++ b/builder/frameworks/kendryte-standalone-sdk.py
@@ -8,11 +8,18 @@ env = DefaultEnvironment()
 
 FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-kendryte-standalone-sdk")
 assert FRAMEWORK_DIR and isdir(FRAMEWORK_DIR)
+TOOLCHAIN_DIR = env.PioPlatform().get_package_dir("toolchain-kendryte210")
+assert TOOLCHAIN_DIR and isdir(TOOLCHAIN_DIR)
 
 env.SConscript("_bare.py", exports="env")
 
 env.Append(
 
+    CCFLAGS = [
+        "-ffast-math",
+        "-fno-math-errno",
+        "-fsingle-precision-constant",
+    ],
 
     CPPDEFINES = [
         ("NNCASE_TARGET", "k210"),
@@ -22,10 +29,15 @@ env.Append(
 
     LINKFLAGS = [
         "-Wl,--start-group",
-        "-lc",
+        # explicitly add C runtime initialization and end, otherwise "undefined reference to `__dso_handle'"
+        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crti.o"),
+        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtbegin.o"),
         "-lgcc",
         "-lm",
-        "-Wl,--end-group"
+        "-lc",
+        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtend.o"),
+        join(TOOLCHAIN_DIR, "lib","gcc", "riscv64-unknown-elf", "8.2.0", "crtn.o"),
+        "-Wl,--end-group",
     ],
 
     CPPPATH = [
@@ -40,16 +52,23 @@ env.Append(
         join(FRAMEWORK_DIR, "lib", "utils", "include"),
         join(FRAMEWORK_DIR, "lib", "nncase"),
         join(FRAMEWORK_DIR, "lib", "nncase", "include"),
-        join(FRAMEWORK_DIR, "lib", "nncase", "runtime"),
-        join(FRAMEWORK_DIR, "third_party", "xtl", "include")
+        join(FRAMEWORK_DIR, "lib", "nncase", "v0"),
+        join(FRAMEWORK_DIR, "lib", "nncase", "v0", "include"),
+        join(FRAMEWORK_DIR, "lib", "nncase", "v1"),
+        join(FRAMEWORK_DIR, "lib", "nncase", "v1", "include"),
+        join(FRAMEWORK_DIR, "lib", "nncase", "include"),
+        join(FRAMEWORK_DIR, "third_party", "xtl", "include"),
+        join(FRAMEWORK_DIR, "third_party", "gsl-lite", "include"),
+        join(FRAMEWORK_DIR, "third_party", "mpark-variant", "include"),
+        join(FRAMEWORK_DIR, "third_party", "nlohmann_json", "include")
     ],
 
     LIBPATH = [
-
+        join(FRAMEWORK_DIR, "lib", "nncase", "v1", "lib"),
     ],
 
     LIBS = [
-        "c", "gcc", "m", "stdc++"
+       "gcc", "m", "c", "nncase.runtime", "nncase.rt_modules.k210", "stdc++",
     ]
 
 )

--- a/builder/main.py
+++ b/builder/main.py
@@ -105,7 +105,7 @@ if upload_protocol == "kflash":
             "-p", port_str,
             "-b", "$UPLOAD_SPEED",
             "-B", board.get("upload.burn_tool"),
-            "-S" if board.get("upload.slow") else ""
+            "-S" if board.get("upload.slow", False) else ""
         ],
 
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE',

--- a/platform.json
+++ b/platform.json
@@ -61,7 +61,7 @@
             "type": "framework",
             "optional": true,
             "owner": "platformio",
-            "version": "~0.5.6"
+            "version": "https://github.com/kendryte/kendryte-standalone-sdk.git"
         },
         "framework-kendryte-freertos-sdk": {
             "type": "framework",


### PR DESCRIPTION
Recent projects like https://github.com/kendryte/kendryte-standalone-demo/tree/develop/face_detect cannot be compiled under PlatformIO because the SDK (https://github.com/kendryte/kendryte-standalone-sdk) package it uses has become outdated with respect to the master branch, and so, errors like

```
src\image_process.c:18:10: fatal error: iomem.h: No such file or directory
```

are encountered. Sadly Sipeed doesn't seem to be making regular releases of the SDK anymore (V0.5.6 is from **May 2019**) but the SDK is still being further developed.

This PR mainly updates the builder script `builder/frameworks/kendryte-standalone-sdk.py` to adapt to the new SDK version and compilation settings. It also incorporates PR #39 because otherwise a Python error occurs. It also changes the version of `framework-kendryte-standalone-sdk` to point directly to the `git` version, however, after a merge this should changed back to a stable package version together with an updated version of that package (CC @ivankravets). 

A test project that showcases working compilation with this updated version and non-working of it with the current version is located at https://github.com/maxgerhardt/pio-kendryte-facedetect-demo.

This stems from a user's post about not being able to compile the reference project at https://community.platformio.org/t/kendryte-face-detect-example-with-sipeed-maix-bit/24763.

Also linked to #31. 